### PR TITLE
Improve offline instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,60 @@ Various encryption algorithms for my own playground.
 
 ## Available Implementations
 
-- **chacha20_poly1305**: A command line tool implemented in Rust that performs encryption and decryption using ChaCha20-Poly1305 with an Argon2 key derivation function and optional file hash verification.
+- **chacha20_poly1305**: Command line tool implemented in Rust that performs encryption and decryption using ChaCha20-Poly1305 with an Argon2 key derivation function and optional file hash verification.
 
-## Setup
+## Installation
 
-Run `setup.sh` to install the Rust toolchain and fetch crate dependencies. The
-script requires root privileges because it uses `apt-get` to install build
-tools. After running it you can build the project with `cargo build`.
+Run the provided setup script to install all build dependencies and the Rust toolchain:
+
+```bash
+sudo ./setup.sh
+```
+
+The script installs required system packages, sets up `rustup` if `rustc` is not present and fetches all crate dependencies.
+If you already have Rust installed you can skip it and simply run `cargo fetch`.
+
+## Building
+
+```bash
+cargo build --release
+```
+
+The resulting binary will be located at `target/release/chacha20_poly1305`.
+
+## Usage
+
+```
+chacha20_poly1305 <encrypt|decrypt> <INPUT> <OUTPUT> <PASSWORD> [--verify-hash <HEX>]
+```
+
+Arguments:
+
+- `INPUT` – path to the file to read.
+- `OUTPUT` – path of the file to write.
+- `PASSWORD` – password used for the Argon2 key derivation.
+- `--verify-hash` – optional hex-encoded SHA256 hash of the encrypted file to verify before decryption.
+
+Example encrypt:
+
+```bash
+chacha20_poly1305 encrypt plain.txt secret.bin mypassword
+```
+
+Example decrypt with integrity check:
+
+```bash
+chacha20_poly1305 decrypt secret.bin plain.txt mypassword --verify-hash <hash>
+```
+
+## Running Tests
+
+To run tests without a network connection you must prefetch the dependencies
+first:
+
+```bash
+cargo fetch
+cargo test --offline
+```
+
+This will compile the project and execute the tests found in the `tests/` directory entirely offline once the dependencies have been fetched.

--- a/setup.sh
+++ b/setup.sh
@@ -5,17 +5,25 @@
 
 set -euo pipefail
 
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run as root" >&2
+    exit 1
+fi
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    build-essential curl git pkg-config libssl-dev
+
 if ! command -v rustc >/dev/null 2>&1; then
-    apt-get update
-    apt-get install -y --no-install-recommends build-essential curl
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     source "$HOME/.cargo/env"
 fi
 
-# Fetch Rust crate dependencies
-cargo fetch
+# Fetch Rust crate dependencies and generate Cargo.lock
+cargo fetch --locked
 
 # Optionally build the project (uncomment to build)
 # cargo build --release
 
 echo "Setup complete."
+


### PR DESCRIPTION
## Summary
- advise how to run tests offline in README
- use `cargo fetch --locked` in setup script to create a lock file

## Testing
- `cargo test --offline` *(fails: no crates cached)*