### PR TITLE
Add constant-time read and comparison hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Example decrypt with integrity check:
 chacha20_poly1305 decrypt secret.bin plain.txt mypassword --verify-hash <hash>
 ```
 
+## Security Notes
+
+This tool reads input files using a constant-time routine and performs all tag
+comparisons using constant-time equality checks to reduce timing side channels.
+
 ## Running Tests
 
 To run tests without a network connection you must prefetch the dependencies

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@
 
 use anyhow::{Result, bail};
 use clap::{Parser, Subcommand};
-use hex;
 use rand::{RngCore, rngs::OsRng};
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -19,7 +18,7 @@ use zeroize::Zeroize;
 
 use encryptor::{
     Argon2Config, HEADER_LEN, MAGIC, chacha20_block, ct_eq, derive_key, encrypt_decrypt,
-    poly1305_tag, unlock,
+    poly1305_tag, read_file_ct, unlock,
 };
 
 #[derive(Parser)]
@@ -62,7 +61,7 @@ fn main() -> Result<()> {
         time_cost: args.iterations,
         parallelism: args.parallelism,
     };
-    let mut data = fs::read(&args.input_file)?;
+    let mut data = read_file_ct(&args.input_file)?;
     match args.mode {
         Mode::Encrypt => {
             let mut header = Vec::with_capacity(HEADER_LEN);
@@ -111,30 +110,37 @@ fn main() -> Result<()> {
             header.zeroize();
         }
         Mode::Decrypt => {
-            if data.len() < HEADER_LEN + 16 {
-                bail!("Input too short");
-            }
+            let mut failure = false;
             if let Some(expected_hex) = &args.verify_hash {
                 let mut hasher = Sha256::new();
                 hasher.update(&data);
                 let actual_hex = hex::encode(hasher.finalize());
-                if &actual_hex != expected_hex {
-                    bail!(
-                        "Hash mismatch: expected {} but got {}",
-                        expected_hex,
-                        actual_hex
-                    );
+                if !ct_eq(actual_hex.as_bytes(), expected_hex.as_bytes()) {
+                    failure = true;
                 }
             }
-            let header = &data[..HEADER_LEN];
-            if &header[..4] != MAGIC {
-                bail!("Invalid file format");
-            }
-            if header[4] != 1 {
-                bail!("Unsupported version");
-            }
-            let mut salt: [u8; 16] = header[8..24].try_into().unwrap();
-            let mut nonce: [u8; 12] = header[24..36].try_into().unwrap();
+
+            let length_ok = data.len() >= HEADER_LEN + 16;
+            let mut header_buf = [0u8; HEADER_LEN];
+            let header = if length_ok {
+                header_buf.copy_from_slice(&data[..HEADER_LEN]);
+                &header_buf
+            } else {
+                &header_buf
+            };
+
+            let magic_ok = ct_eq(&header[..4], MAGIC);
+            let version_ok = ct_eq(&[header[4]], &[1]);
+            let mut salt: [u8; 16] = if length_ok {
+                data[8..24].try_into().unwrap()
+            } else {
+                [0u8; 16]
+            };
+            let mut nonce: [u8; 12] = if length_ok {
+                data[24..36].try_into().unwrap()
+            } else {
+                [0u8; 12]
+            };
             let mut key = derive_key(&args.password, &salt, &cfg)?;
             let mut block0 = chacha20_block(&key, 0, &nonce);
             let mut r_bytes = [0u8; 16];
@@ -153,22 +159,40 @@ fn main() -> Result<()> {
             block0.zeroize();
             r_bytes.zeroize();
             s_bytes.zeroize();
-            let ct_len = data.len() - HEADER_LEN - 16;
-            let ciphertext = &data[HEADER_LEN..HEADER_LEN + ct_len];
-            let tag = &data[HEADER_LEN + ct_len..];
+            let ct_len = if length_ok {
+                data.len() - HEADER_LEN - 16
+            } else {
+                0
+            };
+            let ciphertext = if length_ok {
+                &data[HEADER_LEN..HEADER_LEN + ct_len]
+            } else {
+                &[]
+            };
+            let tag = if length_ok {
+                &data[HEADER_LEN + ct_len..]
+            } else {
+                &[0u8; 16][..]
+            };
             let expected = poly1305_tag(&r, &s, header, ciphertext);
-            if !ct_eq(&expected, tag) {
-                bail!("Authentication failure");
+            let auth_ok = ct_eq(&expected, tag);
+            if length_ok && magic_ok && version_ok && auth_ok && !failure {
+                let mut plaintext = encrypt_decrypt(ciphertext, &key, &nonce);
+                fs::write(&args.output_file, &plaintext)?;
+                plaintext.zeroize();
+            } else {
+                failure = true;
             }
-            let mut plaintext = encrypt_decrypt(ciphertext, &key, &nonce);
-            fs::write(&args.output_file, &plaintext)?;
-            plaintext.zeroize();
+
             key.zeroize();
             #[cfg(unix)]
             unlock(&key);
             data.zeroize();
             nonce.zeroize();
             salt.zeroize();
+            if failure {
+                bail!("Authentication failure");
+            }
         }
     }
     Ok(())

--- a/tests/encryption.rs
+++ b/tests/encryption.rs
@@ -1,4 +1,6 @@
-use encryptor::{Argon2Config, chacha20_block, ct_eq, derive_key, encrypt_decrypt, poly1305_tag};
+use encryptor::{
+    Argon2Config, chacha20_block, ct_eq, derive_key, encrypt_decrypt, poly1305_tag, read_file_ct,
+};
 
 #[test]
 fn encrypt_decrypt_roundtrip() {
@@ -172,4 +174,23 @@ fn cli_argon2_flags_parse() {
     assert_eq!(args.mem_size, 128);
     assert_eq!(args.iterations, 5);
     assert_eq!(args.parallelism, 3);
+}
+
+#[test]
+fn read_file_ct_matches_std() {
+    use std::fs::{self, File};
+    use std::io::Write;
+    let path = "test_read_ct.tmp";
+    let mut f = File::create(path).unwrap();
+    f.write_all(b"data").unwrap();
+    let expected = fs::read(path).unwrap();
+    let actual = read_file_ct(&std::path::PathBuf::from(path)).unwrap();
+    assert_eq!(expected, actual);
+    fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn read_file_ct_error() {
+    let result = read_file_ct(&std::path::PathBuf::from("does_not_exist"));
+    assert!(result.is_err());
 }


### PR DESCRIPTION
## Summary
- add constant-time file read routine
- harden decryption path to avoid timing leaks
- add unit tests for `read_file_ct`
- document constant-time behavior in README

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --offline`
