### PR TITLE
Add CI, dependabot, and docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Cache cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            vendor
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run checks
+        run: |
+          cargo fmt -- --check
+          cargo clippy -- -D warnings
+          cargo test --offline

--- a/CD_PLAN.md
+++ b/CD_PLAN.md
@@ -1,0 +1,21 @@
+# Continuous Deployment Plan
+
+This project currently provides only a binary. A simple CD approach can publish release artifacts whenever changes are merged into the `main` branch.
+
+1. **Build**
+   - Run the existing CI workflow to ensure `cargo fmt`, `cargo clippy` and `cargo test --offline` succeed.
+   - Build a release binary using `cargo build --release`.
+
+2. **Package**
+   - Archive the binary from `target/release/chacha20_poly1305`.
+   - Optionally create a Docker image containing the executable for easier distribution.
+
+3. **Release**
+   - Use `actions/create-release` to publish a GitHub Release with the built artifact.
+   - Tag the release with the crate version from `Cargo.toml`.
+
+4. **Deploy**
+   - For internal use, download the release artifact and deploy to the target environment (e.g., copy to servers or upload to a package repository).
+   - If using a container image, push it to a registry and deploy using the chosen orchestration tool.
+
+This plan can be expanded later with automated signing, multi-platform builds and staging environments.

--- a/README.md
+++ b/README.md
@@ -70,3 +70,10 @@ cargo test --offline
 ```
 
 This will compile the project and execute the tests found in the `tests/` directory entirely offline once the dependencies have been fetched.
+
+## Attack Vectors and Known Issues
+
+- **Nonce reuse**: the tool relies on randomly generated nonces but does not enforce uniqueness. Reusing the same password and nonce combination can reveal information about the plaintext.
+- **Home-grown ChaCha20 implementation**: the `chacha20_block` routine in `src/lib.rs` implements the cipher manually and has not been audited for constant-time behavior or correctness.
+- **Low Argon2 parameters**: default KDF parameters are set to 64 MiB memory and 4 iterations which may not be sufficient against determined attackers. Adjust `--mem-size`, `--iterations` and `--parallelism` as needed.
+- **CLI argument order**: the actual invocation format is `[INPUT] [OUTPUT] [PASSWORD] <encrypt|decrypt>` as seen in the tests. Passing arguments in the order shown above will fail.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for Rust checks and tests
- enable dependabot for cargo and GitHub Actions
- document potential attack vectors and known issues
- outline a continuous deployment plan

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --offline`
