### PR TITLE
Derive nonce from salt

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ This will compile the project and execute the tests found in the `tests/` direct
 
 ## Attack Vectors and Known Issues
 
-- **Nonce reuse**: the tool relies on randomly generated nonces but does not enforce uniqueness. Reusing the same password and nonce combination can reveal information about the plaintext.
+- **Nonce reuse**: nonces are now deterministically derived from each encryption's random salt, ensuring a unique nonce whenever the salt is unique.
 - **Home-grown ChaCha20 implementation**: the `chacha20_block` routine in `src/lib.rs` implements the cipher manually and has not been audited for constant-time behavior or correctness.
 - **Low Argon2 parameters**: default KDF parameters are set to 64 MiB memory and 4 iterations which may not be sufficient against determined attackers. Adjust `--mem-size`, `--iterations` and `--parallelism` as needed.

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,8 +79,11 @@ fn main() -> Result<()> {
         let mut salt = [0u8; 16];
         OsRng.fill_bytes(&mut salt);
         header.extend_from_slice(&salt);
+        // derive nonce deterministically from the random salt to avoid accidental reuse
+        let mut hash: [u8; 32] = Sha256::digest(salt).into();
         let mut nonce = [0u8; 12];
-        OsRng.fill_bytes(&mut nonce);
+        nonce.copy_from_slice(&hash[..12]);
+        hash.zeroize();
         header.extend_from_slice(&nonce);
         let mut key = derive_key(&args.password, &salt, &cfg)?;
         let mut block0 = chacha20_block(&key, 0, &nonce);


### PR DESCRIPTION
## Summary
- deterministically derive the encryption nonce from the random salt
- document the new nonce generation approach

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --offline`
