### PR TITLE
Add CD workflow, Dockerfile and build script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustfmt, clippy
+      - name: Format
+        run: cargo fmt -- --check
+      - name: Lint
+        run: cargo clippy -- -D warnings
+      - name: Test
+        run: cargo test --offline
+      - name: Build
+        run: cargo build --release
+      - name: Get version
+        id: version
+        run: echo "version=$(grep '^version' Cargo.toml | head -n1 | cut -d '"' -f2)" >> "$GITHUB_OUTPUT"
+      - name: Archive binary
+        run: |
+          mkdir artifacts
+          cp target/release/chacha20_poly1305 artifacts/
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          release_name: v${{ steps.version.outputs.version }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/chacha20_poly1305
+          asset_name: chacha20_poly1305
+          asset_content_type: application/octet-stream

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+# Multi-stage build for encryptor
+FROM rust:latest AS builder
+WORKDIR /usr/src/encryptor
+COPY . .
+RUN cargo build --release
+
+FROM debian:bullseye-slim AS runtime
+COPY --from=builder /usr/src/encryptor/target/release/chacha20_poly1305 /usr/local/bin/chacha20_poly1305
+ENTRYPOINT ["chacha20_poly1305"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ sudo ./setup.sh
 The script installs required system packages, sets up `rustup` if `rustc` is not present and fetches all crate dependencies.
 If you already have Rust installed you can skip it and simply run `cargo fetch`.
 
+After installing the toolchain you can vendor the dependencies and compile the binary in one step using the `build.sh` helper script:
+
+```bash
+./build.sh
+```
+
 ## Building
 
 ```bash
@@ -24,6 +30,16 @@ cargo build --release
 ```
 
 The resulting binary will be located at `target/release/chacha20_poly1305`.
+
+## Docker
+
+A `Dockerfile` is provided for building a container image with the release binary.
+Build and run it with:
+
+```bash
+docker build -t encryptor .
+docker run --rm encryptor --help
+```
 
 ## Usage
 
@@ -70,6 +86,13 @@ cargo test --offline
 ```
 
 This will compile the project and execute the tests found in the `tests/` directory entirely offline once the dependencies have been fetched.
+
+## Continuous Deployment
+
+Merges to the `main` branch trigger a GitHub Actions workflow that
+formats the code, lints with Clippy, runs the test suite and builds a
+release binary. The resulting executable is published as a GitHub
+release using the crate version from `Cargo.toml`.
 
 ## Attack Vectors and Known Issues
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Allow network access to pull crates
+export CARGO_NET_OFFLINE=false
+
+# Ensure lockfile and vendor directory are up to date
+cargo generate-lockfile
+cargo vendor
+
+# Switch to offline mode for the build
+export CARGO_NET_OFFLINE=true
+mkdir -p .cargo
+cat > .cargo/config.toml <<'EOC'
+[net]
+offline = true
+
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"
+EOC
+
+# Build release binary using vendored crates
+cargo build --release --offline


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for automatic releases on main
- provide `Dockerfile` for running the application in a container
- add `build.sh` helper script to vendor crates and build release binary
- document new build script, Docker usage and CD process in README

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test --offline`
