### PR TITLE
Fix release binary name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "encryptor"
+autobins = false
 version = "0.1.0"
 edition = "2024"
 
@@ -13,3 +14,7 @@ sha2 = "0.10"
 hex = "0.4"
 poly1305 = "0.8.0"
 libc = "0.2"
+
+[[bin]]
+name = "chacha20_poly1305"
+path = "src/main.rs"


### PR DESCRIPTION
## Summary
- add a dedicated binary target `chacha20_poly1305`
- disable auto bin generation so only that binary is produced

## Testing
- `cargo test --offline`
- `cargo clippy -- -D warnings`
