### PR TITLE
Fix release workflow token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ steps.version.outputs.version }}
           release_name: v${{ steps.version.outputs.version }}
@@ -44,6 +46,8 @@ jobs:
           prerelease: false
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/chacha20_poly1305


### PR DESCRIPTION
## Summary
- ensure release job uses `${{ secrets.GITHUB_TOKEN }}` to authenticate `create-release` and `upload-release-asset` steps

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --offline`