### PR TITLE
Add SECURITY.md and CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 0 * * 0'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: rust
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # encryptor
 
-Various encryption algorithms for my own playground.
+A set of encryption experiments. Currently it includes only the `chacha20_poly1305` tool.
 
 ## Available Implementations
 
@@ -96,6 +96,10 @@ release using the crate version from `Cargo.toml`.
 
 ## Attack Vectors and Known Issues
 
-- **Nonce reuse**: nonces are now deterministically derived from each encryption's random salt, ensuring a unique nonce whenever the salt is unique.
 - **Home-grown ChaCha20 implementation**: the `chacha20_block` routine in `src/lib.rs` implements the cipher manually and has not been audited for constant-time behavior or correctness.
 - **Low Argon2 parameters**: default KDF parameters are set to 64 MiB memory and 4 iterations which may not be sufficient against determined attackers. Adjust `--mem-size`, `--iterations` and `--parallelism` as needed.
+
+## Reporting Vulnerabilities
+
+Please see [SECURITY.md](SECURITY.md) for instructions on how to privately
+report security issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+If you discover a security vulnerability in this project, please use GitHub's
+"Report a vulnerability" feature to notify the maintainers. Alternatively, you
+may email us at gh-vulnerabilities.judge874@simplelogin.com. Please do not disclose issues publicly
+until we have a chance to address them.
+
+We strive to respond to security reports within a few working days.


### PR DESCRIPTION
## Summary
- add `SECURITY.md` describing how to report vulnerabilities
- configure a CodeQL analysis workflow for Rust
- mention the security policy in the README
- clarify that only the ChaCha20-Poly1305 tool is provided
- remove obsolete nonce reuse note
- update security contact email

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test --offline`
