### PR TITLE
Add security scanning to CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,15 @@ jobs:
             ~/.cargo/git
             vendor
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install security tools
+        run: |
+          cargo install --version ^0.17 cargo-audit
+          cargo install --version ^0.11 cargo-deny
+          cargo install --version ^0.2 cargo-auditable
       - name: Run checks
         run: |
           cargo fmt -- --check
           cargo clippy -- -D warnings
           cargo test --offline
+          cargo audit --locked --deny warnings
+          cargo deny check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,25 @@ jobs:
           toolchain: stable
           profile: minimal
           components: rustfmt, clippy
+      - name: Install security tools
+        run: |
+          cargo install --version ^0.17 cargo-audit
+          cargo install --version ^0.11 cargo-deny
+          cargo install --version ^0.2 cargo-auditable
       - name: Format
         run: cargo fmt -- --check
       - name: Lint
         run: cargo clippy -- -D warnings
       - name: Test
         run: cargo test --offline
+      - name: Dependency audit
+        run: cargo audit --locked --deny warnings
       - name: Build
-        run: cargo build --release
+        run: cargo auditable build --release
+      - name: Policy check
+        run: cargo deny check
+      - name: Binary audit
+        run: cargo audit --json target/release/chacha20_poly1305
       - name: Determine next version
         id: version
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,5 @@ cython_debug/
 *cargo.lock
 *cargo.LOCK
 *.Cargo.lock
+src/built_info.rs
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "encryptor"
 autobins = false
 version = "0.1.0"
 edition = "2024"
+build = "build.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ Merges to the `main` branch trigger a GitHub Actions workflow that
 formats the code, lints with Clippy, runs the test suite and builds a
 release binary. The resulting executable is published as a GitHub
 release using the crate version from `Cargo.toml`.
+Additional steps scan for vulnerable dependencies with `cargo-audit`,
+enforce licensing policy via `cargo-deny` and embed metadata using
+`cargo-auditable`.
 
 ## Attack Vectors and Known Issues
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,20 @@
+use std::fs;
+use std::process::Command;
+
+fn main() {
+    let out_file = "src/built_info.rs";
+    let status = Command::new("cargo")
+        .args(["auditable", "generate", "--output", out_file])
+        .status();
+    match status {
+        Ok(s) if s.success() => {}
+        _ => {
+            let _ = fs::write(
+                out_file,
+                "#[used]\npub static AUDITABLE_METADATA: &[u8] = b\"\";\n",
+            );
+            println!("cargo:warning=cargo-auditable not found; using empty metadata");
+        }
+    }
+    println!("cargo:rerun-if-changed=Cargo.lock");
+}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,7 @@
+[sources.crates-io]
+
+[[licenses.ban]]
+name = "GPL-3.0"
+
+[advisories]
+deny-warnings = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,12 @@
 // sha2 = "0.10"
 // hex = "0.4"
 
+// Include dependency metadata for cargo-auditable
+#[allow(dead_code)]
+mod built_info {
+    include!("built_info.rs");
+}
+
 use anyhow::{Result, bail};
 use clap::{Args, Parser, Subcommand};
 use rand::{RngCore, rngs::OsRng};


### PR DESCRIPTION
## Summary
- add `cargo-audit`, `cargo-deny` and `cargo-auditable` checks in CI and release workflows
- generate `built_info.rs` at build time via new build script
- include metadata module in binary
- provide deny.toml policy file
- document security checks in README

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --offline`
