### PR TITLE
Add cargo-audit caching and macOS release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,25 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Cache cargo
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          vendor
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo-audit
+        id: cache-audit
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            vendor
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          path: ~/.cargo/bin/cargo-audit
+          key: ${{ runner.os }}-cargo-audit-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install cargo-audit
+        if: steps.cache-audit.outputs.cache-hit != 'true'
+        run: cargo install --version ^0.17 cargo-audit
       - name: Run checks
         run: |
           cargo fmt -- --check
           cargo clippy -- -D warnings
           cargo test --offline
+          cargo audit --locked --deny warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,26 +9,131 @@ permissions:
   contents: write
 
 jobs:
-  build-release:
+  build-linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           components: rustfmt, clippy
-      - name: Format
-        run: cargo fmt -- --check
-      - name: Lint
-        run: cargo clippy -- -D warnings
-      - name: Test
-        run: cargo test --offline
-      - name: Build
-        run: cargo build --release
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            vendor
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo-audit
+        id: cache-audit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: ${{ runner.os }}-cargo-audit-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install cargo-audit
+        if: steps.cache-audit.outputs.cache-hit != 'true'
+        run: cargo install --version ^0.17 cargo-audit
+      - run: cargo fmt -- --check
+      - run: cargo clippy -- -D warnings
+      - run: cargo test --offline
+      - run: cargo audit --locked --deny warnings
+      - run: cargo build --release
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-x86_64
+          path: target/release/chacha20_poly1305
+
+  build-macos-x86:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustfmt, clippy
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            vendor
+          key: macos-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo-audit
+        id: cache-audit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: macos-cargo-audit-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install cargo-audit
+        if: steps.cache-audit.outputs.cache-hit != 'true'
+        run: cargo install --version ^0.17 cargo-audit
+      - run: cargo fmt -- --check
+      - run: cargo clippy -- -D warnings
+      - run: cargo test --offline
+      - run: cargo audit --locked --deny warnings
+      - run: cargo build --release
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: macos-x86_64
+          path: target/release/chacha20_poly1305
+
+  build-macos-arm:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustfmt, clippy
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            vendor
+          key: macos-arm-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo-audit
+        id: cache-audit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: macos-arm-cargo-audit-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install cargo-audit
+        if: steps.cache-audit.outputs.cache-hit != 'true'
+        run: cargo install --version ^0.17 cargo-audit
+      - run: rustup target add aarch64-apple-darwin
+      - run: cargo fmt -- --check
+      - run: cargo clippy -- -D warnings
+      - run: cargo test --offline
+      - run: cargo audit --locked --deny warnings
+      - run: cargo build --release --target aarch64-apple-darwin
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: macos-aarch64
+          path: target/aarch64-apple-darwin/release/chacha20_poly1305
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [build-linux, build-macos-x86, build-macos-arm]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Determine next version
         id: version
         run: |
@@ -44,10 +149,6 @@ jobs:
             version="$major.$minor.0"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
-      - name: Archive binary
-        run: |
-          mkdir artifacts
-          cp target/release/chacha20_poly1305 artifacts/
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -58,12 +159,35 @@ jobs:
           release_name: v${{ steps.version.outputs.version }}
           draft: false
           prerelease: false
-      - name: Upload Release Asset
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+      - name: Upload linux asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: artifacts/chacha20_poly1305
-          asset_name: chacha20_poly1305
+          asset_path: artifacts/linux-x86_64/chacha20_poly1305
+          asset_name: chacha20_poly1305-linux-x86_64
           asset_content_type: application/octet-stream
+      - name: Upload macOS x86 asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/macos-x86_64/chacha20_poly1305
+          asset_name: chacha20_poly1305-macos-x86_64
+          asset_content_type: application/octet-stream
+      - name: Upload macOS ARM asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: artifacts/macos-aarch64/chacha20_poly1305
+          asset_name: chacha20_poly1305-macos-aarch64
+          asset_content_type: application/octet-stream
+

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,16 @@
+name: Verification
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  prusti:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Prusti
+        uses: viperproject/prusti-action@v0.3
+        with:
+          args: cargo-prusti --manifest-path Cargo.toml
+

--- a/README.md
+++ b/README.md
@@ -90,9 +90,16 @@ This will compile the project and execute the tests found in the `tests/` direct
 ## Continuous Deployment
 
 Merges to the `main` branch trigger a GitHub Actions workflow that
-formats the code, lints with Clippy, runs the test suite and builds a
-release binary. The resulting executable is published as a GitHub
-release using the crate version from `Cargo.toml`.
+formats the code, lints with Clippy, runs the test suite, performs a
+`cargo audit` vulnerability scan and builds a release binary. The
+resulting executables for Linux and macOS are published as GitHub release
+artifacts using the crate version from `Cargo.toml`. Binaries are built
+for `x86_64-unknown-linux-gnu`, `x86_64-apple-darwin` and
+`aarch64-apple-darwin`. Releases run the same audit before publishing
+artifacts.
+
+An additional verification workflow executes the [Prusti](https://github.com/viperproject/prusti-dev)
+tool to prove selected invariants in the cipher implementation.
 
 ## Attack Vectors and Known Issues
 

--- a/setup.sh
+++ b/setup.sh
@@ -3,14 +3,15 @@ export CARGO_NET_OFFLINE=false
 
 rustup component add rustfmt
 rustup component add clippy
+cargo install --version ^0.17 cargo-audit
 
-# 2. Generate or update Cargo.lock (needed so vendor knows exactly what to pull) :contentReference[oaicite:0]{index=0}
+# 2. Generate or update Cargo.lock (needed so vendor knows exactly what to pull)
 cargo generate-lockfile
 
-# 3. Vendor ALL direct+transitive crates locally :contentReference[oaicite:1]{index=1}
+# 3. Vendor ALL direct+transitive crates locally
 cargo vendor
 
-# 4. Now lock down to offline-only mode :contentReference[oaicite:2]{index=2}
+# 4. Now lock down to offline-only mode
 export CARGO_NET_OFFLINE=true
 
 # 5. Tell Cargo where to find vendored crates

--- a/tests/data/sample.txt
+++ b/tests/data/sample.txt
@@ -1,0 +1,2 @@
+This is a sample test file.
+It has multiple lines.

--- a/tests/integration_roundtrip.rs
+++ b/tests/integration_roundtrip.rs
@@ -1,0 +1,46 @@
+use rand::random;
+use std::fs;
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_chacha20_poly1305");
+
+fn run_roundtrip(input: &str, password: &str) {
+    let mut enc = std::env::temp_dir();
+    enc.push(format!("enc-{}-{}.bin", password, random::<u32>()));
+    let mut dec = std::env::temp_dir();
+    dec.push(format!("dec-{}-{}.txt", password, random::<u32>()));
+
+    let status = Command::new(BIN)
+        .args(["encrypt", input, enc.to_str().unwrap(), password])
+        .status()
+        .expect("encrypt run");
+    assert!(status.success());
+
+    let status = Command::new(BIN)
+        .args([
+            "decrypt",
+            enc.to_str().unwrap(),
+            dec.to_str().unwrap(),
+            password,
+        ])
+        .status()
+        .expect("decrypt run");
+    assert!(status.success());
+
+    let orig = fs::read(input).unwrap();
+    let new = fs::read(&dec).unwrap();
+    assert_eq!(orig, new);
+
+    let _ = fs::remove_file(enc);
+    let _ = fs::remove_file(dec);
+}
+
+#[test]
+fn roundtrip_sample_file() {
+    run_roundtrip("tests/data/sample.txt", "pass123");
+}
+
+#[test]
+fn roundtrip_empty_file() {
+    run_roundtrip("tests/data/empty.txt", "pass123");
+}


### PR DESCRIPTION
## Summary
- clean up setup script comments
- document multi-platform release artifacts
- build and upload Linux and macOS binaries in release workflow

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --offline`
