### PR TITLE
Add macOS builds to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
 name: CD
-
 on:
   push:
     branches:
@@ -11,6 +10,8 @@ permissions:
 jobs:
   build-release:
     runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -98,4 +99,37 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: artifacts/chacha20_poly1305
           asset_name: chacha20_poly1305
+          asset_content_type: application/octet-stream
+
+  build-macos:
+    needs: build-release
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target: [x86_64-apple-darwin, aarch64-apple-darwin]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+
+      - name: Add target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.build-release.outputs.upload_url }}
+          asset_path: target/${{ matrix.target }}/release/chacha20_poly1305
+          asset_name: chacha20_poly1305-${{ matrix.target }}
           asset_content_type: application/octet-stream

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ This will compile the project and execute the tests found in the `tests/` direct
 Merges to the `main` branch trigger a GitHub Actions workflow that
 formats the code, lints with Clippy, runs the test suite, performs a
 `cargo audit` vulnerability scan and builds a release binary. The
-resulting executable is published as a GitHub release using the crate
-version from `Cargo.toml`. Releases run the same audit before
-publishing artifacts.
+resulting executables are published as a GitHub release using the crate
+version from `Cargo.toml`. Linux, macOS x86 and macOS arm64 binaries are
+uploaded. Releases run the same audit before publishing artifacts.
 
 An additional verification workflow executes the [Prusti](https://github.com/viperproject/prusti-dev)
 tool to prove selected invariants in the cipher implementation.


### PR DESCRIPTION
## Summary
- add darwin x86_64 and arm64 cross-compiles in release workflow
- mention new binaries in README

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --offline`
