### PR TITLE
Add compile-fail test for secret key API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ This file defines guidance for AI assistants (Codex) when interacting with the *
 * **Zeroization**: Wrap secrets in `secrecy::Secret` and use `Zeroize` on ephemeral buffers.
 * **AEAD**: Authenticate headers & ciphertext with Poly1305; verify before decryption.
 * **KDF Hardening**: Expose and bound Argon2 `mem_cost`, `time_cost`, `parallelism`.
+* **Streaming API**: Functions like `encrypt_decrypt_in_place` must accept `&Secret<[u8; 32]>` and unwrap the secret exactly once inside the function body.
 
 ## Workflow Automation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Changed streaming functions to require `&Secret<[u8; 32]>` keys, unwrapping the secret once internally. This improves ergonomics and prevents accidental exposure.

--- a/tests/compile_fail.rs
+++ b/tests/compile_fail.rs
@@ -1,0 +1,40 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn old_api_usage_fails_to_compile() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let crate_dir = dir.path();
+    fs::create_dir_all(crate_dir.join("src")).unwrap();
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let cargo_toml = format!(
+        "[package]\nname = \"failcase\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nencryptor = {{ path = \"{}\" }}\n",
+        manifest_dir.display()
+    );
+    fs::write(crate_dir.join("Cargo.toml"), cargo_toml).unwrap();
+    fs::write(
+        crate_dir.join("src/main.rs"),
+        r#"use encryptor::encrypt_decrypt_in_place;
+fn main() {
+    let mut data = [0u8; 16];
+    let key = [0u8; 32];
+    let nonce = [0u8; 12];
+    let mut counter = 0u32;
+    encrypt_decrypt_in_place(&mut data, &key, &nonce, &mut counter);
+}
+"#,
+    )
+    .unwrap();
+    let output = Command::new("cargo")
+        .arg("check")
+        .arg("--offline")
+        .current_dir(crate_dir)
+        .output()
+        .expect("cargo check");
+    assert!(
+        !output.status.success(),
+        "old API call unexpectedly compiled:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary
- ensure streaming API guidelines documented in AGENTS
- add CHANGELOG entry for Secret key API decision
- add compile-fail test verifying old API shape fails

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test --offline`
