### PR TITLE
Finish secret streaming API and add ChaCha20 vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
 
 ## Unreleased
-- Changed streaming functions to require `&Secret<[u8; 32]>` keys, unwrapping the secret once internally. This improves ergonomics and prevents accidental exposure.
+- Enforce streaming API to take `&Secret<[u8; 32]>` keys and unwrap them once internally.
+- Add RFC-8439 ChaCha20 block test.

--- a/tests/chacha20_vectors.rs
+++ b/tests/chacha20_vectors.rs
@@ -1,0 +1,13 @@
+#[test]
+fn rfc8439_block0() {
+    // Test vector from RFC 8439 \u00a72.3.2
+    let key = [0u8; 32];
+    let nonce = [0u8; 12];
+    let block = encryptor::chacha20_block(&secrecy::Secret::new(key), 1, &nonce);
+    let expected = hex::decode(
+        "9f07e7be5551387a98ba977c732d080dcb0f29a048e3656912c6533e32ee7aed\
+         29b721769ce64e43d57133b074d839d531ed1f28510afb45ace10a1f4b794d6f",
+    )
+    .unwrap();
+    assert_eq!(&block[..], &expected[..]);
+}

--- a/tests/compile_fail.rs
+++ b/tests/compile_fail.rs
@@ -38,3 +38,37 @@ fn main() {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+#[test]
+fn derive_key_wrong_salt_fails() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let crate_dir = dir.path();
+    fs::create_dir_all(crate_dir.join("src")).unwrap();
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let cargo_toml = format!(
+        "[package]\nname = \"failcase2\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nencryptor = {{ path = \"{}\" }}\n",
+        manifest_dir.display()
+    );
+    fs::write(crate_dir.join("Cargo.toml"), cargo_toml).unwrap();
+    fs::write(
+        crate_dir.join("src/main.rs"),
+        r#"use encryptor::{derive_key, Argon2Config};
+fn main() {
+    let cfg = Argon2Config::default();
+    let _ = derive_key("pw", &[0u8; 15], &cfg);
+}
+"#,
+    )
+    .unwrap();
+    let output = Command::new("cargo")
+        .arg("check")
+        .arg("--offline")
+        .current_dir(crate_dir)
+        .output()
+        .expect("cargo check");
+    assert!(
+        !output.status.success(),
+        "derive_key call unexpectedly compiled:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary
- expose secret key only once in `encrypt_decrypt*`
- add compile-fail tests for wrong key type and salt length
- add RFC-8439 ChaCha20 block test vector
- document the streaming API change in CHANGELOG

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --offline`
