### PR TITLE
Configure test threads for CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,5 @@ jobs:
         run: |
           cargo fmt -- --check
           cargo clippy -- -D warnings
-          cargo test
+          RUST_TEST_THREADS=$(nproc) cargo test
           cargo audit --deny warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         run: cargo clippy -- -D warnings
 
       - name: Test
-        run: cargo test
+        run: RUST_TEST_THREADS=$(nproc) cargo test
 
       - name: Security audit
         run: cargo audit --deny warnings


### PR DESCRIPTION
## Summary
- use available vCPU count for RUST_TEST_THREADS in CI and CD

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --offline`
