### PR TITLE
Add Criterion benchmarks and bench diff CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,46 @@ jobs:
         run: |
           cargo fmt -- --check
           cargo clippy -- -D warnings
-          RUST_TEST_THREADS=$(nproc) cargo test
+          RUST_TEST_THREADS=$(nproc) cargo test --offline
           cargo audit --deny warnings
+
+  benchmark:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+      - name: Cache cargo-benchcmp
+        id: cache-benchcmp
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-benchcmp
+          key: ${{ runner.os }}-cargo-benchcmp-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install cargo-benchcmp
+        if: steps.cache-benchcmp.outputs.cache-hit != 'true'
+        run: cargo install cargo-benchcmp
+      - name: Run benches on PR head
+        run: cargo bench -- --save-baseline pr.json
+      - name: Run benches on main
+        run: |
+          git fetch origin main
+          git checkout origin/main
+          cargo bench -- --save-comparison main.json
+      - name: Compare benches
+        run: cargo benchcmp main.json pr.json > bench.diff
+      - name: Post benchmark report
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const diff = require('fs').readFileSync('bench.diff','utf8');
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## 📊 Benchmark delta\n\`\`\`\n${diff}\n\`\`\``
+            });
+

--- a/benches/performance.rs
+++ b/benches/performance.rs
@@ -1,0 +1,34 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use encryptor::{chacha20_block, encrypt_decrypt_in_place};
+use secrecy::Secret;
+
+fn bench_chacha20_block(c: &mut Criterion) {
+    let key = Secret::new([0u8; 32]);
+    let nonce = [0u8; 12];
+    c.bench_function("chacha20_block", |b| {
+        b.iter(|| {
+            black_box(chacha20_block(&key, 1, &nonce));
+        });
+    });
+}
+
+fn bench_encrypt_decrypt_in_place(c: &mut Criterion) {
+    let key = Secret::new([0u8; 32]);
+    let nonce = [0u8; 12];
+    let data = vec![0u8; 1024];
+    c.bench_function("encrypt_decrypt_in_place", |b| {
+        b.iter(|| {
+            let mut buf = data.clone();
+            let mut counter = 0u32;
+            encrypt_decrypt_in_place(&mut buf, &key, &nonce, &mut counter);
+            black_box(buf);
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_chacha20_block,
+    bench_encrypt_decrypt_in_place
+);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- add Criterion benchmark suite for core functions
- install cargo-benchcmp in CI
- benchmark head vs. main and post bench diff on PRs

## Testing
- `cargo clippy -- -D warnings`
- `CARGO_NET_OFFLINE=true cargo test --offline`