### PR TITLE
Add CSS override for rustdoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,8 @@ jobs:
           cargo clippy -- -D warnings
           RUST_TEST_THREADS=$(nproc) cargo test
           cargo audit --deny warnings
-          RUSTDOCFLAGS="--deny broken-intra-doc-links" cargo doc --no-deps --quiet
+          RUSTDOCFLAGS="--deny broken-intra-doc-links" \
+            cargo doc --no-deps --quiet --extend-css docs/rustdoc.css
 
   benchmark:
     name: 📊 Benchmark

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build documentation
         run: |
           cd ${{ github.workspace }}
-          cargo doc --no-deps --release
+          cargo doc --no-deps --release --extend-css docs/rustdoc.css
 
       - name: Deploy GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ After installing the toolchain you can vendor the dependencies and compile the b
 ## Getting started
 
 The library can also be used directly from Rust code. The full API
-documentation can be generated locally using `cargo doc --no-deps` and is
+documentation can be generated locally using
+`cargo doc --no-deps --extend-css docs/rustdoc.css` and is
 included in the repository under the `docs/` directory.
 
 ```rust

--- a/docs/rustdoc.css
+++ b/docs/rustdoc.css
@@ -1,0 +1,12 @@
+body {
+    font-family: "DejaVu Sans", Arial, sans-serif;
+    background-color: #f8f9fa;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    color: #003366;
+}
+
+.content {
+    margin: 1.5em;
+}


### PR DESCRIPTION
## Summary
- add docs/rustdoc.css containing custom theme rules
- use `--extend-css docs/rustdoc.css` when generating docs in CI and publish workflows
- mention the custom flag in README

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test --offline`
- `RUSTDOCFLAGS="--extend-css docs/rustdoc.css" cargo doc --no-deps --offline`