### PR TITLE
Fix verifying key loading error handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -193,13 +193,11 @@ fn try_main() -> Result<()> {
 
     let verify_key = if decrypting {
         if let Some(p) = &args.verify_key {
-            let bytes = fs::read(p)?;
-            if bytes.len() != 32 {
+            let pk_bytes = fs::read(p)?;
+            if pk_bytes.len() != 32 {
                 return Err(Error::FormatError("Invalid key length"));
             }
-            let mut pk = [0u8; 32];
-            pk.copy_from_slice(&bytes);
-            Some(VerifyingKey::from_bytes(&pk).map_err(|_| Error::FormatError("Invalid key"))?)
+            Some(VerifyingKey::try_from(&pk_bytes[..]).map_err(|_| Error::FormatError("Invalid key"))?)
         } else {
             None
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,10 @@ fn try_main() -> Result<()> {
             if pk_bytes.len() != 32 {
                 return Err(Error::FormatError("Invalid key length"));
             }
-            Some(VerifyingKey::try_from(&pk_bytes[..]).map_err(|_| Error::FormatError("Invalid key"))?)
+            Some(
+                VerifyingKey::try_from(&pk_bytes[..])
+                    .map_err(|_| Error::FormatError("Invalid key"))?,
+            )
         } else {
             None
         }


### PR DESCRIPTION
## Summary
- use `VerifyingKey::try_from` when reading a public key file

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --offline`
