### PR TITLE
Add encrypted key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Arguments:
 - `--parallelism` – Argon2 parallelism degree (default: 1).
 - `--sign-key` – path to an Ed25519 private key to sign the encrypted output.
 - `--verify-key` – path to an Ed25519 public key used to verify the signature.
+- `--key-password` – password used when loading or generating an encrypted
+  private key.
 - `--verbose` – print detailed error messages for debugging.
 - `--generate-keys` – generate a new Ed25519 key pair in the given directory and exit.
 
@@ -122,6 +124,13 @@ chacha20_poly1305 encrypt plain.txt secret.bin mypassword \
     --sign-key priv.key
 ```
 
+Using an encrypted key:
+
+```bash
+chacha20_poly1305 encrypt plain.txt secret.bin mypassword \
+    --sign-key priv.ekey --key-password secret
+```
+
 Example decrypt verifying the signature:
 
 ```bash
@@ -133,6 +142,12 @@ Example key generation:
 
 ```bash
 chacha20_poly1305 --generate-keys mykeys
+```
+
+With `--key-password` the private key is encrypted and written as `priv.ekey`:
+
+```bash
+chacha20_poly1305 --generate-keys mykeys --key-password secret
 ```
 
 Private keys must be 32-byte raw Ed25519 seeds and the public key is the

--- a/tests/keygen.rs
+++ b/tests/keygen.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::process::Command;
 
+use encryptor::ENC_KEY_LEN;
+
 const BIN: &str = env!("CARGO_BIN_EXE_chacha20_poly1305");
 
 #[test]
@@ -64,4 +66,85 @@ fn generated_keys_sign_and_verify() {
         fs::read("tests/data/sample.txt").unwrap(),
         fs::read(dec).unwrap()
     );
+}
+
+#[test]
+fn encrypted_key_sign_and_verify() {
+    let dir = tempfile::tempdir().unwrap();
+    Command::new(BIN)
+        .args([
+            "--generate-keys",
+            dir.path().to_str().unwrap(),
+            "--key-password",
+            "pw",
+        ])
+        .status()
+        .expect("run keygen");
+    let priv_key = dir.path().join("priv.ekey");
+    let pub_key = dir.path().join("pub.key");
+    assert_eq!(fs::read(&priv_key).unwrap().len(), ENC_KEY_LEN);
+
+    let enc = dir.path().join("out.bin");
+    let dec = dir.path().join("out.txt");
+
+    let status = Command::new(BIN)
+        .args([
+            "encrypt",
+            "tests/data/sample.txt",
+            enc.to_str().unwrap(),
+            "pw1",
+            "--sign-key",
+            priv_key.to_str().unwrap(),
+            "--key-password",
+            "pw",
+        ])
+        .status()
+        .expect("encrypt");
+    assert!(status.success());
+
+    let status = Command::new(BIN)
+        .args([
+            "decrypt",
+            enc.to_str().unwrap(),
+            dec.to_str().unwrap(),
+            "pw1",
+            "--verify-key",
+            pub_key.to_str().unwrap(),
+        ])
+        .status()
+        .expect("decrypt");
+    assert!(status.success());
+    assert_eq!(
+        fs::read("tests/data/sample.txt").unwrap(),
+        fs::read(dec).unwrap()
+    );
+}
+
+#[test]
+fn encrypted_key_missing_password_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    Command::new(BIN)
+        .args([
+            "--generate-keys",
+            dir.path().to_str().unwrap(),
+            "--key-password",
+            "pw",
+        ])
+        .status()
+        .expect("run keygen");
+    let priv_key = dir.path().join("priv.ekey");
+    let enc = dir.path().join("out.bin");
+
+    let status = Command::new(BIN)
+        .args([
+            "encrypt",
+            "tests/data/sample.txt",
+            enc.to_str().unwrap(),
+            "pw2",
+            "--sign-key",
+            priv_key.to_str().unwrap(),
+        ])
+        .status()
+        .expect("encrypt");
+    assert!(!status.success());
 }


### PR DESCRIPTION
## Summary
- support encrypted private key files using ChaCha20-Poly1305
- add `--key-password` CLI option
- write encrypted keys with `--generate-keys --key-password`
- allow signing with encrypted keys
- document new flag and examples
- test key encryption and password handling

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test --offline`
