### PR TITLE
Use secure password prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,58 +83,59 @@ docker run --rm encryptor --help
 ## Usage
 
 ```
-chacha20_poly1305 <encrypt|decrypt> <INPUT> <OUTPUT> <PASSWORD> \
+chacha20_poly1305 <encrypt|decrypt> <INPUT> <OUTPUT> \
     [--verify-hash <HEX>] [--mem-size <MiB>] [--iterations <N>] [--parallelism <N>] \
-    [--sign-key <FILE>] [--verify-key <FILE>] [--verbose]
-chacha20_poly1305 --generate-keys <DIR>
+    [--sign-key <FILE>] [--verify-key <FILE>] [--key-password] [--verbose]
+chacha20_poly1305 --generate-keys <DIR> [--key-password]
 ```
 
 Arguments:
 
 - `INPUT` – path to the file to read.
 - `OUTPUT` – path of the file to write.
-- `PASSWORD` – password used for the Argon2 key derivation.
 - `--verify-hash` – optional hex-encoded SHA256 hash of the encrypted file to verify before decryption.
 - `--mem-size` – Argon2 memory usage in MiB (default: 64).
 - `--iterations` – Argon2 iterations/passes (default: 4).
 - `--parallelism` – Argon2 parallelism degree (default: 1).
 - `--sign-key` – path to an Ed25519 private key to sign the encrypted output.
 - `--verify-key` – path to an Ed25519 public key used to verify the signature.
-- `--key-password` – password used when loading or generating an encrypted
+- `--key-password` – prompt for a password when loading or generating an encrypted
   private key.
 - `--verbose` – print detailed error messages for debugging.
 - `--generate-keys` – generate a new Ed25519 key pair in the given directory and exit.
+- Passwords can also be supplied using the `FILE_PASSWORD` and
+  `KEY_PASSWORD` environment variables for non-interactive use.
 
 Example encrypt:
 
 ```bash
-chacha20_poly1305 encrypt plain.txt secret.bin mypassword
+chacha20_poly1305 encrypt plain.txt secret.bin
 ```
 
 Example decrypt with integrity check:
 
 ```bash
-chacha20_poly1305 decrypt secret.bin plain.txt mypassword --verify-hash <hash>
+chacha20_poly1305 decrypt secret.bin plain.txt --verify-hash <hash>
 ```
 
 Example encrypt with a signature:
 
 ```bash
-chacha20_poly1305 encrypt plain.txt secret.bin mypassword \
+chacha20_poly1305 encrypt plain.txt secret.bin \
     --sign-key priv.key
 ```
 
 Using an encrypted key:
 
 ```bash
-chacha20_poly1305 encrypt plain.txt secret.bin mypassword \
-    --sign-key priv.ekey --key-password secret
+chacha20_poly1305 encrypt plain.txt secret.bin \
+    --sign-key priv.ekey --key-password
 ```
 
 Example decrypt verifying the signature:
 
 ```bash
-chacha20_poly1305 decrypt secret.bin plain.txt mypassword \
+chacha20_poly1305 decrypt secret.bin plain.txt \
     --verify-key pub.key
 ```
 
@@ -147,7 +148,7 @@ chacha20_poly1305 --generate-keys mykeys
 With `--key-password` the private key is encrypted and written as `priv.ekey`:
 
 ```bash
-chacha20_poly1305 --generate-keys mykeys --key-password secret
+chacha20_poly1305 --generate-keys mykeys --key-password
 ```
 
 Private keys must be 32-byte raw Ed25519 seeds and the public key is the

--- a/tests/integration_roundtrip.rs
+++ b/tests/integration_roundtrip.rs
@@ -12,18 +12,15 @@ fn run_roundtrip(input: &str, password: &str) {
     dec.push(format!("dec-{}.txt", random::<u32>()));
 
     let status = Command::new(BIN)
-        .args(["encrypt", input, enc.to_str().unwrap(), password])
+        .args(["encrypt", input, enc.to_str().unwrap()])
+        .env("FILE_PASSWORD", password)
         .status()
         .expect("encrypt run");
     assert!(status.success());
 
     let status = Command::new(BIN)
-        .args([
-            "decrypt",
-            enc.to_str().unwrap(),
-            dec.to_str().unwrap(),
-            password,
-        ])
+        .args(["decrypt", enc.to_str().unwrap(), dec.to_str().unwrap()])
+        .env("FILE_PASSWORD", password)
         .status()
         .expect("decrypt run");
     assert!(status.success());

--- a/tests/integration_tamper.rs
+++ b/tests/integration_tamper.rs
@@ -10,7 +10,8 @@ fn encrypt_file(input: &str, password: &str) -> std::path::PathBuf {
     let mut out = std::env::temp_dir();
     out.push(format!("enc-{}-{}.bin", password, random::<u32>()));
     let status = Command::new(BIN)
-        .args(["encrypt", input, out.to_str().unwrap(), password])
+        .args(["encrypt", input, out.to_str().unwrap()])
+        .env("FILE_PASSWORD", password)
         .status()
         .expect("run encrypt");
     assert!(status.success());
@@ -24,7 +25,8 @@ fn decrypt_file(
     verify: Option<&str>,
 ) -> std::process::ExitStatus {
     let mut cmd = Command::new(BIN);
-    cmd.arg("decrypt").arg(input).arg(output).arg(password);
+    cmd.arg("decrypt").arg(input).arg(output);
+    cmd.env("FILE_PASSWORD", password);
     if let Some(v) = verify {
         cmd.arg("--verify-hash").arg(v);
     }

--- a/tests/keygen.rs
+++ b/tests/keygen.rs
@@ -42,10 +42,10 @@ fn generated_keys_sign_and_verify() {
             "encrypt",
             "tests/data/sample.txt",
             enc.to_str().unwrap(),
-            "pass",
             "--sign-key",
             priv_key.to_str().unwrap(),
         ])
+        .env("FILE_PASSWORD", "pass")
         .status()
         .expect("encrypt");
     assert!(status.success());
@@ -55,10 +55,10 @@ fn generated_keys_sign_and_verify() {
             "decrypt",
             enc.to_str().unwrap(),
             dec.to_str().unwrap(),
-            "pass",
             "--verify-key",
             pub_key.to_str().unwrap(),
         ])
+        .env("FILE_PASSWORD", "pass")
         .status()
         .expect("decrypt");
     assert!(status.success());
@@ -76,8 +76,8 @@ fn encrypted_key_sign_and_verify() {
             "--generate-keys",
             dir.path().to_str().unwrap(),
             "--key-password",
-            "pw",
         ])
+        .env("KEY_PASSWORD", "pw")
         .status()
         .expect("run keygen");
     let priv_key = dir.path().join("priv.ekey");
@@ -92,12 +92,12 @@ fn encrypted_key_sign_and_verify() {
             "encrypt",
             "tests/data/sample.txt",
             enc.to_str().unwrap(),
-            "pw1",
             "--sign-key",
             priv_key.to_str().unwrap(),
             "--key-password",
-            "pw",
         ])
+        .env("FILE_PASSWORD", "pw1")
+        .env("KEY_PASSWORD", "pw")
         .status()
         .expect("encrypt");
     assert!(status.success());
@@ -107,10 +107,10 @@ fn encrypted_key_sign_and_verify() {
             "decrypt",
             enc.to_str().unwrap(),
             dec.to_str().unwrap(),
-            "pw1",
             "--verify-key",
             pub_key.to_str().unwrap(),
         ])
+        .env("FILE_PASSWORD", "pw1")
         .status()
         .expect("decrypt");
     assert!(status.success());
@@ -128,8 +128,8 @@ fn encrypted_key_missing_password_fails() {
             "--generate-keys",
             dir.path().to_str().unwrap(),
             "--key-password",
-            "pw",
         ])
+        .env("KEY_PASSWORD", "pw")
         .status()
         .expect("run keygen");
     let priv_key = dir.path().join("priv.ekey");
@@ -140,10 +140,10 @@ fn encrypted_key_missing_password_fails() {
             "encrypt",
             "tests/data/sample.txt",
             enc.to_str().unwrap(),
-            "pw2",
             "--sign-key",
             priv_key.to_str().unwrap(),
         ])
+        .env("FILE_PASSWORD", "pw2")
         .status()
         .expect("encrypt");
     assert!(!status.success());

--- a/tests/signing.rs
+++ b/tests/signing.rs
@@ -29,10 +29,10 @@ fn sign_verify_roundtrip() {
             "encrypt",
             "tests/data/sample.txt",
             enc.to_str().unwrap(),
-            "pass",
             "--sign-key",
             priv_key.to_str().unwrap(),
         ])
+        .env("FILE_PASSWORD", "pass")
         .status()
         .expect("encrypt");
     assert!(status.success());
@@ -42,10 +42,10 @@ fn sign_verify_roundtrip() {
             "decrypt",
             enc.to_str().unwrap(),
             dec.to_str().unwrap(),
-            "pass",
             "--verify-key",
             pub_key.to_str().unwrap(),
         ])
+        .env("FILE_PASSWORD", "pass")
         .status()
         .expect("decrypt");
     assert!(status.success());
@@ -67,10 +67,10 @@ fn verify_fails_on_bad_signature() {
             "encrypt",
             "tests/data/sample.txt",
             enc.to_str().unwrap(),
-            "pw",
             "--sign-key",
             priv_key.to_str().unwrap(),
         ])
+        .env("FILE_PASSWORD", "pw")
         .status()
         .unwrap();
 
@@ -84,10 +84,10 @@ fn verify_fails_on_bad_signature() {
             "decrypt",
             enc.to_str().unwrap(),
             dec.to_str().unwrap(),
-            "pw",
             "--verify-key",
             pub_key.to_str().unwrap(),
         ])
+        .env("FILE_PASSWORD", "pw")
         .status()
         .unwrap();
     assert!(!status.success());
@@ -101,12 +101,8 @@ fn verify_fails_when_missing_signature() {
     let dec = dir.path().join("dec.txt");
 
     Command::new(BIN)
-        .args([
-            "encrypt",
-            "tests/data/sample.txt",
-            enc.to_str().unwrap(),
-            "pw2",
-        ])
+        .args(["encrypt", "tests/data/sample.txt", enc.to_str().unwrap()])
+        .env("FILE_PASSWORD", "pw2")
         .status()
         .unwrap();
 
@@ -115,10 +111,10 @@ fn verify_fails_when_missing_signature() {
             "decrypt",
             enc.to_str().unwrap(),
             dec.to_str().unwrap(),
-            "pw2",
             "--verify-key",
             pub_key.to_str().unwrap(),
         ])
+        .env("FILE_PASSWORD", "pw2")
         .status()
         .unwrap();
     assert!(!status.success());
@@ -137,10 +133,10 @@ fn warn_on_permissive_sign_key() {
             "encrypt",
             "tests/data/sample.txt",
             enc.to_str().unwrap(),
-            "pw",
             "--sign-key",
             priv_key.to_str().unwrap(),
         ])
+        .env("FILE_PASSWORD", "pw")
         .output()
         .expect("encrypt");
     assert!(output.status.success());


### PR DESCRIPTION
## Summary
- implement interactive password prompts using a small helper
- adjust CLI flags to trigger prompting
- update integration tests to use environment variables
- document new usage in README

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --offline`