### PR TITLE
Remove --key-password flag and add warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,6 @@
 - Add RFC-8439 ChaCha20 block-function vector test.
 - Private key generated with `--generate-keys` now uses `0o600` permissions and a
   warning is shown when loading a signing key that is too permissive.
+- Removed the `--key-password` flag. Key generation and encrypted key loading
+  now always prompt for a password; leaving it blank stores the key unencrypted
+  and prints a warning.


### PR DESCRIPTION
## Summary
- drop `--key-password` CLI flag and prompt automatically for key passwords
- warn when generating unencrypted keys
- update docs to recommend `--generate-keys` and describe signing
- adjust tests for new prompting behaviour

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --offline`