### PR TITLE
Improve docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,15 +141,22 @@ Example key generation:
 chacha20_poly1305 --generate-keys mykeys
 ```
 
-You will be prompted for a password protecting the private key. Leaving the
-password empty stores the key unencrypted and a warning is printed.
+We **recommend** generating keys with this command. It creates a new Ed25519
+key pair using the correct format, encrypts the private key when a password is
+supplied and stores the files with secure permissions. You will be prompted for
+a password protecting the private key. Leaving the password empty stores the key
+unencrypted and a warning is printed.
 
 Private keys must be 32-byte raw Ed25519 seeds and the public key is the
 corresponding 32-byte verifying key. When a seed is loaded, the program expands
 it into the full 64 byte keypair internally so both halves are available for
-signing and verification. Keys can be generated using
-`openssl rand -out priv.key 32` and deriving the public key with a tool such as
-[`ed25519-dalek`](https://docs.rs/ed25519-dalek/). Alternatively, run
+signing and verification.
+
+Keys can also be generated manually using `openssl rand -out priv.key 32` and
+deriving the public key with a tool such as
+[`ed25519-dalek`](https://docs.rs/ed25519-dalek/), but using our program is
+preferred because it performs the encryption and sets the permissions
+correctly. Alternatively, run
 
 ```bash
 chacha20_poly1305 --generate-keys ./keys

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,12 @@ static VERBOSE: AtomicBool = AtomicBool::new(false);
 
 /// Enable or disable verbose error output for conversions from `std::io::Error`
 /// and `argon2::Error`.
+///
+/// # Examples
+///
+/// ```
+/// encryptor::error::set_verbose(true);
+/// ```
 pub fn set_verbose(val: bool) {
     VERBOSE.store(val, Ordering::Relaxed);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,6 +432,17 @@ pub const KEY_MAGIC: &[u8; 6] = b"EDEKV1";
 pub const ENC_KEY_LEN: usize = KEY_MAGIC.len() + 4 + 4 + 4 + 16 + 12 + 32 + 16;
 
 /// Encrypt an Ed25519 seed using ChaCha20-Poly1305 with an Argon2 key.
+///
+/// # Examples
+///
+/// ```
+/// use encryptor::{encrypt_priv_key, decrypt_priv_key, Argon2Config};
+/// let seed = [0u8; 32];
+/// let cfg = Argon2Config::default();
+/// let enc = encrypt_priv_key(&seed, "pw", &cfg).unwrap();
+/// let dec = decrypt_priv_key(&enc, "pw").unwrap();
+/// assert_eq!(seed, dec);
+/// ```
 pub fn encrypt_priv_key(seed: &[u8; 32], password: &str, cfg: &Argon2Config) -> Result<Vec<u8>> {
     use poly1305::{
         universal_hash::{KeyInit, UniversalHash},
@@ -497,6 +508,17 @@ pub fn encrypt_priv_key(seed: &[u8; 32], password: &str, cfg: &Argon2Config) -> 
 }
 
 /// Decrypt an encrypted Ed25519 seed.
+///
+/// # Examples
+///
+/// ```
+/// use encryptor::{encrypt_priv_key, decrypt_priv_key, Argon2Config};
+/// let seed = [0u8; 32];
+/// let cfg = Argon2Config::default();
+/// let enc = encrypt_priv_key(&seed, "pw", &cfg).unwrap();
+/// let dec = decrypt_priv_key(&enc, "pw").unwrap();
+/// assert_eq!(seed, dec);
+/// ```
 pub fn decrypt_priv_key(data: &[u8], password: &str) -> Result<[u8; 32]> {
     use poly1305::{
         universal_hash::{KeyInit, UniversalHash},

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,17 @@ use poly1305::{
     Block, Key, Poly1305,
 };
 
+/// Update a Poly1305 instance with `data`, buffering incomplete blocks.
+///
+/// # Examples
+///
+/// ```ignore
+/// use poly1305::{Poly1305, universal_hash::KeyInit};
+/// use poly1305::Key;
+/// let mut poly = Poly1305::new(Key::from_slice(&[0u8; 32]));
+/// let mut leftover = Vec::new();
+/// poly_update_stream(&mut poly, b"data", &mut leftover);
+/// ```
 fn poly_update_stream(poly: &mut Poly1305, mut data: &[u8], leftover: &mut Vec<u8>) {
     if !leftover.is_empty() {
         let need = 16 - leftover.len();
@@ -48,6 +59,14 @@ fn poly_update_stream(poly: &mut Poly1305, mut data: &[u8], leftover: &mut Vec<u
     }
 }
 
+/// Compute the hexadecimal SHA256 hash of the file at `path`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let hash = sha256_file(&std::path::PathBuf::from("Cargo.toml")).unwrap();
+/// assert_eq!(hash.len(), 64);
+/// ```
 fn sha256_file(path: &PathBuf) -> Result<String> {
     let mut hasher = Sha256::new();
     let mut file = BufReader::new(File::open(path)?);
@@ -62,12 +81,27 @@ fn sha256_file(path: &PathBuf) -> Result<String> {
     Ok(hex::encode(hasher.finalize()))
 }
 
+/// Prompt the user for a password using `rpassword`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let pw = prompt_env("Password: ").unwrap();
+/// println!("{}", pw.len());
+/// ```
 fn prompt_env(prompt: &str) -> io::Result<String> {
     let mut input = io::stdin().lock();
     let mut output = io::stdout();
     prompt_password_from_bufread(&mut input, &mut output, prompt)
 }
 
+/// Generate an Ed25519 key pair in `dir` optionally encrypting the private key.
+///
+/// # Examples
+///
+/// ```no_run
+/// generate_keys(&std::path::PathBuf::from("keys"), Some("pw")).unwrap();
+/// ```
 fn generate_keys(dir: &PathBuf, password: Option<&str>) -> Result<()> {
     fs::create_dir_all(dir)?;
     let sk = SigningKey::generate(&mut OsRng);
@@ -160,6 +194,13 @@ struct ModeArgs {
     verify_key: Option<PathBuf>,
 }
 
+/// Entry point that prints errors to stderr.
+///
+/// # Examples
+///
+/// ```ignore
+/// main();
+/// ```
 fn main() {
     if let Err(e) = try_main() {
         eprintln!("{}", e);
@@ -167,6 +208,15 @@ fn main() {
     }
 }
 
+/// Execute the command line interface logic.
+///
+/// # Examples
+///
+/// ```ignore
+/// if let Err(e) = try_main() {
+///     eprintln!("{e}");
+/// }
+/// ```
 fn try_main() -> Result<()> {
     let cli = Cli::parse();
     set_verbose(cli.verbose);


### PR DESCRIPTION
## Summary
- add missing docs to every function in `src/`
- update README key generation section to recommend using the built-in command
- add examples to the new documentation

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --offline` *(fails to capture full output due to time, but tests pass)*