### PR TITLE
Add high-level constant-time checks

### DIFF
--- a/tests/constant_time.rs
+++ b/tests/constant_time.rs
@@ -1,4 +1,4 @@
-use encryptor::ct_eq;
+use encryptor::{ct_eq, decrypt_priv_key, encrypt_priv_key, Argon2Config, ENC_KEY_LEN};
 use std::time::Instant;
 
 // Run the given closure `iters` times, returning elapsed duration
@@ -13,14 +13,16 @@ fn bench<F: FnMut()>(mut f: F, iters: usize) -> std::time::Duration {
 #[test]
 fn ct_eq_timing_consistency() {
     const LEN: usize = 1024;
-    const ITERS: usize = 100_000;
+    const ITERS: usize = 250;
 
     let a = vec![0u8; LEN];
     let mut b = vec![0u8; LEN];
 
     let equal = bench(
         || {
-            let _ = ct_eq(&a, &b);
+            for _ in 0..100 {
+                let _ = ct_eq(&a, &b);
+            }
         },
         ITERS,
     );
@@ -28,7 +30,9 @@ fn ct_eq_timing_consistency() {
     b[0] = 1;
     let diff_first = bench(
         || {
-            let _ = ct_eq(&a, &b);
+            for _ in 0..100 {
+                let _ = ct_eq(&a, &b);
+            }
         },
         ITERS,
     );
@@ -37,7 +41,9 @@ fn ct_eq_timing_consistency() {
     b[LEN - 1] = 1;
     let diff_last = bench(
         || {
-            let _ = ct_eq(&a, &b);
+            for _ in 0..100 {
+                let _ = ct_eq(&a, &b);
+            }
         },
         ITERS,
     );
@@ -46,7 +52,7 @@ fn ct_eq_timing_consistency() {
     fn similar(a: std::time::Duration, b: std::time::Duration) -> bool {
         let (long, short) = if a > b { (a, b) } else { (b, a) };
         let diff = long - short;
-        diff.as_secs_f64() < long.as_secs_f64() * 0.20
+        diff.as_secs_f64() < long.as_secs_f64() * 0.10
     }
 
     assert!(
@@ -56,5 +62,58 @@ fn ct_eq_timing_consistency() {
     assert!(
         similar(diff_first, diff_last),
         "first vs last byte diff timing skew too high"
+    );
+}
+
+#[test]
+fn decrypt_priv_key_timing_consistency() {
+    const ITERS: usize = 250;
+
+    let seed = [0u8; 32];
+    let cfg = Argon2Config {
+        mem_cost_kib: 64,
+        time_cost: 1,
+        parallelism: 1,
+    };
+    let enc = encrypt_priv_key(&seed, "pw", &cfg).unwrap();
+
+    let decrypt_good = bench(
+        || {
+            let _ = decrypt_priv_key(&enc, "pw");
+        },
+        ITERS,
+    );
+
+    let mut diff_first = enc.clone();
+    diff_first[ENC_KEY_LEN - 16] ^= 1;
+    let decrypt_diff_first = bench(
+        || {
+            let _ = decrypt_priv_key(&diff_first, "pw");
+        },
+        ITERS,
+    );
+
+    let mut diff_last = enc.clone();
+    diff_last[ENC_KEY_LEN - 1] ^= 1;
+    let decrypt_diff_last = bench(
+        || {
+            let _ = decrypt_priv_key(&diff_last, "pw");
+        },
+        ITERS,
+    );
+
+    fn similar(a: std::time::Duration, b: std::time::Duration) -> bool {
+        let (long, short) = if a > b { (a, b) } else { (b, a) };
+        let diff = long - short;
+        diff.as_secs_f64() < long.as_secs_f64() * 0.10
+    }
+
+    assert!(
+        similar(decrypt_good, decrypt_diff_first),
+        "decrypt vs diff_first timing skew too high"
+    );
+    assert!(
+        similar(decrypt_diff_first, decrypt_diff_last),
+        "diff_first vs diff_last timing skew too high"
     );
 }


### PR DESCRIPTION
## Summary
- expand `tests/constant_time.rs` to test more than just `ct_eq`
- verify `decrypt_priv_key` timing consistency
- tighten variance threshold to 10% and run 250 iterations
- benchmark each iteration with inner loops for stability

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --offline`
