### PR TITLE
Add path filters to CI/CD workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,20 @@ name: CI
 
 on:
   pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'src/**'
+      - 'tests/**'
+      - 'benches/**'
   push:
     branches: [main]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'src/**'
+      - 'tests/**'
+      - 'benches/**'
 
 jobs:
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,20 @@ name: CodeQL
 on:
   push:
     branches: [ main ]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'src/**'
+      - 'tests/**'
+      - 'benches/**'
   pull_request:
     branches: [ main ]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'src/**'
+      - 'tests/**'
+      - 'benches/**'
   schedule:
     - cron: '0 0 * * 0'
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,6 +3,15 @@ name: Publish Docs
 on:
   push:
     branches: [main]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'src/**'
+      - 'tests/**'
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'SECURITY.md'
+      - 'docs/**'
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'src/**'
+      - 'tests/**'
+      - 'benches/**'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- limit CI runs to code, tests, benches and dependency updates
- restrict CodeQL, docs and release workflows to the same file changes

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --offline`
