### PR TITLE
Fix secrecy 0.10 API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ tests:
 - `Argon2Config` lets you tune the memory cost, number of passes and
   parallelism used by the Argon2id key derivation.
 - `derive_key(password, salt, cfg)` produces a 32 byte ChaCha20 key wrapped in
-  [`Secret<[u8; 32]>`](https://docs.rs/secrecy/latest/secrecy/struct.Secret.html).
+  [`SecretBox<[u8; 32]>`](https://docs.rs/secrecy/latest/secrecy/struct.SecretBox.html).
 - `encrypt_decrypt` processes a byte slice and returns the encrypted or
   decrypted output.
 - `encrypt_decrypt_in_place` operates on a buffer in place while updating an

--- a/benches/encryptor_benches.rs
+++ b/benches/encryptor_benches.rs
@@ -2,10 +2,10 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use ed25519_dalek::SigningKey;
 use encryptor::{chacha20_block, encrypt_decrypt_in_place, sign, verify, Ed25519PrivKey};
 use rand_core::OsRng;
-use secrecy::Secret;
+use secrecy::SecretBox;
 
 fn bench_chacha20_block(c: &mut Criterion) {
-    let key = Secret::new([0u8; 32]);
+    let key = SecretBox::new(Box::new([0u8; 32]));
     let nonce = [0u8; 12];
     c.bench_function("chacha20_block", |b| {
         b.iter(|| {
@@ -15,7 +15,7 @@ fn bench_chacha20_block(c: &mut Criterion) {
 }
 
 fn bench_encrypt_decrypt_in_place(c: &mut Criterion) {
-    let key = Secret::new([0u8; 32]);
+    let key = SecretBox::new(Box::new([0u8; 32]));
     let nonce = [0u8; 12];
     let data = vec![0u8; 1024];
     c.bench_function("encrypt_decrypt_in_place", |b| {
@@ -40,7 +40,7 @@ fn bench_keypair_generation(c: &mut Criterion) {
 fn bench_encrypt_with_keypair(c: &mut Criterion) {
     let mut rng = OsRng;
     let sk = SigningKey::generate(&mut rng);
-    let key = Secret::new([0u8; 32]);
+    let key = SecretBox::new(Box::new([0u8; 32]));
     let nonce = [0u8; 12];
     let data = vec![0u8; 1024];
     c.bench_function("encrypt_with_keypair", |b| {
@@ -58,7 +58,7 @@ fn bench_decrypt_with_keypair(c: &mut Criterion) {
     let mut rng = OsRng;
     let sk = SigningKey::generate(&mut rng);
     let pk = sk.verifying_key();
-    let key = Secret::new([0u8; 32]);
+    let key = SecretBox::new(Box::new([0u8; 32]));
     let nonce = [0u8; 12];
     let data = vec![0u8; 1024];
     // pre-encrypt and sign so benchmark focuses on verify+decrypt

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use argon2::{Algorithm, Argon2, Params, Version};
 #[cfg(unix)]
 use libc::{mlock, munlock};
 use rayon::prelude::*;
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretBox};
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -121,7 +121,11 @@ pub fn unlock(_buf: &[u8]) -> std::io::Result<()> {
 /// let key = derive_key("pw", b"0123456789abcdef", &cfg).unwrap();
 /// assert_eq!(key.expose_secret().len(), 32);
 /// ```
-pub fn derive_key(password: &str, salt: &[u8; 16], cfg: &Argon2Config) -> Result<Secret<[u8; 32]>> {
+pub fn derive_key(
+    password: &str,
+    salt: &[u8; 16],
+    cfg: &Argon2Config,
+) -> Result<SecretBox<[u8; 32]>> {
     let params =
         Params::new(cfg.mem_cost_kib, cfg.time_cost, cfg.parallelism, None).map_err(Error::from)?;
     let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
@@ -131,7 +135,7 @@ pub fn derive_key(password: &str, salt: &[u8; 16], cfg: &Argon2Config) -> Result
         .hash_password_into(password.as_bytes(), salt, &mut key_bytes)
         .map_err(Error::from)?;
     unlock(&key_bytes).map_err(Error::from)?;
-    Ok(Secret::new(key_bytes))
+    Ok(SecretBox::new(Box::new(key_bytes)))
 }
 
 /// Rotate `v` left by `c` bits.
@@ -251,7 +255,7 @@ fn chacha20_block_bytes(key_bytes: &[u8; 32], counter: u32, nonce: &[u8; 12]) ->
 /// let block = chacha20_block(&key, 0, &[0u8; 12]);
 /// assert_eq!(block.len(), 64);
 /// ```
-pub fn chacha20_block(key: &Secret<[u8; 32]>, counter: u32, nonce: &[u8; 12]) -> [u8; 64] {
+pub fn chacha20_block(key: &SecretBox<[u8; 32]>, counter: u32, nonce: &[u8; 12]) -> [u8; 64] {
     chacha20_block_bytes(key.expose_secret(), counter, nonce)
 }
 
@@ -319,7 +323,7 @@ pub fn read_file_ct(path: &Path) -> Result<Vec<u8>> {
 /// let plain = encrypt_decrypt(&cipher, &key, &nonce);
 /// assert_eq!(plain, b"hello");
 /// ```
-pub fn encrypt_decrypt(data: &[u8], key: &Secret<[u8; 32]>, nonce: &[u8; 12]) -> Vec<u8> {
+pub fn encrypt_decrypt(data: &[u8], key: &SecretBox<[u8; 32]>, nonce: &[u8; 12]) -> Vec<u8> {
     let mut out = data.to_vec();
     let mut counter = 1u32;
     encrypt_decrypt_in_place(&mut out, key, nonce, &mut counter);
@@ -347,7 +351,7 @@ pub fn encrypt_decrypt(data: &[u8], key: &Secret<[u8; 32]>, nonce: &[u8; 12]) ->
 /// ```
 pub fn encrypt_decrypt_in_place(
     data: &mut [u8],
-    key: &Secret<[u8; 32]>,
+    key: &SecretBox<[u8; 32]>,
     nonce: &[u8; 12],
     counter: &mut u32,
 ) {

--- a/tests/chacha20_vectors.rs
+++ b/tests/chacha20_vectors.rs
@@ -1,12 +1,12 @@
 use encryptor::chacha20_block;
-use secrecy::Secret;
+use secrecy::SecretBox;
 
 #[test]
 fn rfc8439_block0() {
     // Test vector from RFC 8439 \u00a72.3.2
     let key = [0u8; 32];
     let nonce = [0u8; 12];
-    let block = chacha20_block(&Secret::new(key), 1, &nonce);
+    let block = chacha20_block(&SecretBox::new(Box::new(key)), 1, &nonce);
     let expected = hex::decode(
         "9f07e7be5551387a98ba977c732d080dcb0f29a048e3656912c6533e32ee7aed\
          29b721769ce64e43d57133b074d839d531ed1f28510afb45ace10a1f4b794d6f",
@@ -18,11 +18,11 @@ fn rfc8439_block0() {
 #[test]
 fn rfc8439_block1() {
     // RFC 8439 \u00a72.3.2 test vector: counter=1, key=0..31
-    let key = Secret::new([
+    let key = SecretBox::new(Box::new([
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
         0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
         0x1e, 0x1f,
-    ]);
+    ]));
     let nonce = [
         0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x4a, 0x00, 0x00, 0x00, 0x00,
     ];


### PR DESCRIPTION
## Summary
- switch from a custom `Secret` wrapper to `secrecy::SecretBox`
- update tests and benchmarks for the new API
- adjust README to document `SecretBox`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --offline`
