### PR TITLE
Fix rand_core usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "poly1305",
  "proptest",
  "rand 0.9.1",
+ "rand_core 0.6.4",
  "rand_core 0.9.3",
  "rayon",
  "rpassword",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ subtle = "2.4"
 rpassword = "7.4"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 rand_core = { version = "0.9", features = ["std"] }
+rand_core06 = { package = "rand_core", version = "0.6.4", features = ["std"] }
 
 [dev-dependencies]
 proptest = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,7 +452,7 @@ pub fn encrypt_priv_key(seed: &[u8; 32], password: &str, cfg: &Argon2Config) -> 
         universal_hash::{KeyInit, UniversalHash},
         Block, Key, Poly1305,
     };
-    use rand_core::{OsRng, RngCore};
+    use rand_core::{OsRng, TryRngCore};
 
     let mut salt = [0u8; 16];
     OsRng.try_fill_bytes(&mut salt).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@
 
 use clap::{Args, Parser, Subcommand};
 use encryptor::error::{set_verbose, Error, Result};
-use rand_core::{OsRng, RngCore};
+use rand_core::{OsRng, TryRngCore};
+use rand_core06::OsRng as OsRng06;
 use rpassword::prompt_password_from_bufread;
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
@@ -104,7 +105,7 @@ fn prompt_env(prompt: &str) -> io::Result<String> {
 /// ```
 fn generate_keys(dir: &PathBuf, password: Option<&str>) -> Result<()> {
     fs::create_dir_all(dir)?;
-    let sk = SigningKey::generate(&mut OsRng);
+    let sk = SigningKey::generate(&mut OsRng06);
     let pk = sk.verifying_key();
     let pub_path = dir.join("pub.key");
     let mut sk_bytes = sk.to_bytes();


### PR DESCRIPTION
## Summary
- import `TryRngCore` and `rand_core06::OsRng` for `SigningKey::generate`
- keep vendored alias dependency `rand_core06`
- correct lockfile format back to version 3

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --offline`
