### PR TITLE
Fix rand_core 0.9 compile issues

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,7 +452,7 @@ pub fn encrypt_priv_key(seed: &[u8; 32], password: &str, cfg: &Argon2Config) -> 
         universal_hash::{KeyInit, UniversalHash},
         Block, Key, Poly1305,
     };
-    use rand_core::{OsRng, RngCore};
+    use rand_core::{OsRng, TryRngCore};
 
     let mut salt = [0u8; 16];
     OsRng.try_fill_bytes(&mut salt).unwrap();


### PR DESCRIPTION
## Summary
- import TryRngCore for new rand_core API
- use OsRng.try_fill_bytes and SigningKey::from_bytes for key generation
- drop rand_core 0.6 alias
- keep lockfile format version 3

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --offline`
