### PR TITLE
Add RFC 7539 ChaCha20 vector tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Enforce streaming API to take `&Secret<[u8; 32]>` keys and unwrap them once internally.
 - Add RFC-8439 ChaCha20 block-function vector test.
+- Add additional ChaCha20 block test vectors from RFC 7539 Appendix A.
 - Private key generated with `--generate-keys` now uses `0o600` permissions and a
   warning is shown when loading a signing key that is too permissive.
 - Removed the `--key-password` flag. Key generation and encrypted key loading

--- a/tests/chacha20_vectors.rs
+++ b/tests/chacha20_vectors.rs
@@ -34,3 +34,63 @@ fn rfc8439_block1() {
     .unwrap();
     assert_eq!(&block[..], &expected[..]);
 }
+
+#[test]
+fn appendix_a_block1() {
+    // RFC 7539 Appendix A.1 Test Vector #1: counter=0, key=all zeros
+    let key = SecretBox::new(Box::new([0u8; 32]));
+    let nonce = [0u8; 12];
+    let block = chacha20_block(&key, 0, &nonce);
+    let expected = hex::decode(
+        "76b8e0ada0f13d90405d6ae55386bd28bdd219b8a08ded1aa836efcc8b770dc7\
+         da41597c5157488d7724e03fb8d84a376a43b8f41518a11cc387b669b2ee6586",
+    )
+    .unwrap();
+    assert_eq!(&block[..], &expected[..]);
+}
+
+#[test]
+fn appendix_a_block3() {
+    // RFC 7539 Appendix A.1 Test Vector #3: key with last byte = 1
+    let mut key_bytes = [0u8; 32];
+    key_bytes[31] = 1;
+    let key = SecretBox::new(Box::new(key_bytes));
+    let nonce = [0u8; 12];
+    let block = chacha20_block(&key, 1, &nonce);
+    let expected = hex::decode(
+        "3aeb5224ecf849929b9d828db1ced4dd832025e8018b8160b82284f3c949aa5a\
+         8eca00bbb4a73bdad192b5c42f73f2fd4e273644c8b36125a64addeb006c13a0",
+    )
+    .unwrap();
+    assert_eq!(&block[..], &expected[..]);
+}
+
+#[test]
+fn appendix_a_block4() {
+    // RFC 7539 Appendix A.1 Test Vector #4: second byte of key = 0xff, counter=2
+    let mut key_bytes = [0u8; 32];
+    key_bytes[1] = 0xff;
+    let key = SecretBox::new(Box::new(key_bytes));
+    let nonce = [0u8; 12];
+    let block = chacha20_block(&key, 2, &nonce);
+    let expected = hex::decode(
+        "72d54dfbf12ec44b362692df94137f328fea8da73990265ec1bbbea1ae9af0ca\
+         13b25aa26cb4a648cb9b9d1be65b2c0924a66c54d545ec1b7374f4872e99f096",
+    )
+    .unwrap();
+    assert_eq!(&block[..], &expected[..]);
+}
+
+#[test]
+fn appendix_a_block5() {
+    // RFC 7539 Appendix A.1 Test Vector #5: nonce incremented
+    let key = SecretBox::new(Box::new([0u8; 32]));
+    let nonce = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2];
+    let block = chacha20_block(&key, 0, &nonce);
+    let expected = hex::decode(
+        "c2c64d378cd536374ae204b9ef933fcd1a8b2288b3dfa49672ab765b54ee27c7\
+         8a970e0e955c14f3a88e741b97c286f75f8fc299e8148362fa198a39531bed6d",
+    )
+    .unwrap();
+    assert_eq!(&block[..], &expected[..]);
+}


### PR DESCRIPTION
## Summary
- add additional block function vectors from RFC 7539 Appendix A
- document the new tests in CHANGELOG

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --offline`
