### PR TITLE
Fix TTY check for password prompts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ dependencies = [
  "rand_core 0.9.3",
  "rayon",
  "rpassword",
+ "rtoolbox",
  "secrecy",
  "sha2",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ secrecy = "0.10"
 rayon = "1.5"
 subtle = "2.4"
 rpassword = "7.4"
+rtoolbox = "0.0.3"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 rand_core = { version = "0.9", features = ["std"] }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,9 +90,13 @@ fn sha256_file(path: &PathBuf) -> Result<String> {
 /// println!("{}", pw.len());
 /// ```
 fn prompt_env(prompt: &str) -> io::Result<String> {
-    let mut input = io::stdin().lock();
-    let mut output = io::stdout();
-    prompt_password_from_bufread(&mut input, &mut output, prompt)
+    if rtoolbox::atty::is(rtoolbox::atty::Stream::Stdin) {
+        rpassword::prompt_password(prompt)
+    } else {
+        let mut input = io::stdin().lock();
+        let mut output = io::stdout();
+        prompt_password_from_bufread(&mut input, &mut output, prompt)
+    }
 }
 
 /// Generate an Ed25519 key pair in `dir` optionally encrypting the private key.


### PR DESCRIPTION
## Summary
- detect interactive terminals when prompting for passwords
- fall back to stdin when not a TTY
- add `rtoolbox` as a dependency

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --offline`
